### PR TITLE
Add autoloading information and refine composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
   "require-dev": {
     "solarium/solarium": "~3.3",
     "phpunit/phpunit": "~4.6"
+  },
+  "suggest": {
+    "solarium/solarium": "Allows using the SolrServiceProvider"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
       "role" : "Developer"
     }
   ],
+  "autoload": {
+    "psr-4": {
+      "Subugoe\\Find\\": "Classes/"
+    }
+  },
   "replace": {
     "typo3-ter/find": "self.version",
     "subugoe/find": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "subugoe/find",
   "description": "A frontend for Solr indexes",
-  "version": "1.0.1",
   "type": "typo3-cms-extension",
   "keywords" : ["TYPO3 CMS"],
   "license": ["GPL-2.0+"],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -38,4 +38,9 @@ $EM_CONF[$_EXTKEY] = [
         'conflicts' => [],
         'suggests' => [],
     ],
+    "autoload" => [
+        "psr-4" => [
+            ["Subugoe\\Find\\" => "Classes"]
+        ]
+    ]
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,9 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('find') . 'vendor/autoload.php');
+if (!defined('TYPO3_COMPOSER_MODE') || TYPO3_COMPOSER_MODE === false) {
+    require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('find') . 'vendor/autoload.php');
+}
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
     'Subugoe.' . $_EXTKEY,


### PR DESCRIPTION
Adds autoloader information to both composer.json and ext_emconf.php.

* add solarium to composer package suggestions so that a suggestion is displayed when in composer mode
* don't try to load vendored solarium library when in composer mode. If we are in composer mode, solarium should be required in the top-level composer manifest