### PR TITLE
[!!!] Allow defining multiple connections with custom Service Providers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,78 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+charset = utf-8
+
+# Get rid of whitespace to avoid diffs with a bunch of EOL changes
+trim_trailing_whitespace = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# CSS-Files
+[*.css]
+indent_style = tab
+indent_size = 4
+
+# HTML-Files
+[*.html]
+indent_style = tab
+indent_size = 2
+
+# TMPL-Files
+[*.tmpl]
+indent_style = tab
+indent_size = 4
+
+# LESS-Files
+[*.less]
+indent_style = tab
+indent_size = 4
+
+# JS-Files
+[*.js]
+indent_style = tab
+indent_size = 4
+
+# JSON-Files
+[*.json]
+indent_style = tab
+indent_size = 4
+
+# PHP-Files
+[*.php]
+indent_style = space
+indent_size = 4
+
+# ReST-Files
+[*.rst]
+indent_style = space
+indent_size = 3
+
+# MD-Files
+[*.md]
+indent_style = space
+indent_size = 4
+
+# package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2
+
+# TypoScript
+[*.ts]
+indent_style = space
+indent_size = 2
+
+# XLF-Files
+[*.xlf]
+indent_style = tab
+indent_size = 4
+
+# SQL-Files
+[*.sql]
+indent_style = tab
+indent_size = 2

--- a/Classes/Service/AbstractServiceProvider.php
+++ b/Classes/Service/AbstractServiceProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Subugoe\Find\Service;
+
+abstract class AbstractServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * @var string
+     */
+    protected $connectionName;
+
+    /**
+     * @var array
+     */
+    protected $settings;
+
+    /**
+     * @var array
+     */
+    protected $requestArguments;
+
+    /**
+     * @param string $connectionName
+     * @param array  $settings
+     */
+    public function __construct($connectionName, $settings)
+    {
+        $this->connectionName = $connectionName;
+        $this->settings = $settings;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRequestArguments()
+    {
+        return $this->requestArguments;
+    }
+
+    /**
+     * @param array $requestArguments
+     */
+    public function setRequestArguments($requestArguments)
+    {
+        $this->requestArguments = $requestArguments;
+    }
+}

--- a/Classes/Service/ServiceProviderInterface.php
+++ b/Classes/Service/ServiceProviderInterface.php
@@ -31,6 +31,12 @@ namespace Subugoe\Find\Service;
  */
 interface ServiceProviderInterface
 {
+    /**
+     * @param string $connectionName
+     * @param array $settings
+     */
+    public function __construct($connectionName, $settings);
+
     public function connect();
 
     /**

--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -26,6 +26,7 @@ namespace Subugoe\Find\Service;
  *  This copyright notice MUST APPEAR in all copies of the script!
  * ************************************************************* */
 
+use Solarium\Client;
 use Solarium\Exception\HttpException;
 use Solarium\QueryType\Select\Query\Query;
 use Subugoe\Find\Utility\FrontendUtility;
@@ -36,27 +37,17 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 /**
  * Service provider for solr
  */
-class SolrServiceProvider implements ServiceProviderInterface
+class SolrServiceProvider extends AbstractServiceProvider implements ServiceProviderInterface
 {
     /**
-     * @var \Solarium\Client
+     * @var Client
      */
     protected $connection;
 
     /**
      * @var array
      */
-    protected $settings;
-
-    /**
-     * @var array
-     */
     protected $configuration = [];
-
-    /**
-     * @var array
-     */
-    protected $requestArguments;
 
     /**
      * @var \Solarium\QueryType\Select\Query\Query
@@ -73,29 +64,22 @@ class SolrServiceProvider implements ServiceProviderInterface
      */
     protected $controllerExtensionKey;
 
-    /**
-     * @param $settings
-     */
-    public function __construct($settings)
-    {
-        $this->settings = $settings;
-    }
-
     public function connect()
     {
-        $configuration = [
+        $currentConnectionSettings = $this->settings['connections'][$this->connectionName]['options'];
+        $connectionSettings = [
             'endpoint' => [
                 'localhost' => [
-                    'host' => $this->settings['connection']['host'],
-                    'port' => intval($this->settings['connection']['port']),
-                    'path' => $this->settings['connection']['path'],
-                    'timeout' => $this->settings['connection']['timeout'],
-                    'scheme' => $this->settings['connection']['scheme']
+                    'host' => $currentConnectionSettings['host'],
+                    'port' => intval($currentConnectionSettings['port']),
+                    'path' => $currentConnectionSettings['path'],
+                    'timeout' => $currentConnectionSettings['timeout'],
+                    'scheme' => $currentConnectionSettings['scheme']
                 ]
             ]
         ];
 
-        $this->setConnection(new \Solarium\Client($configuration));
+        $this->setConnection(new Client($connectionSettings));
     }
 
     /**
@@ -192,7 +176,7 @@ class SolrServiceProvider implements ServiceProviderInterface
 
 
     /**
-     * @return \Solarium\Client
+     * @return Client
      */
     protected function getConnection()
     {
@@ -624,7 +608,6 @@ class SolrServiceProvider implements ServiceProviderInterface
      * the highlight to better deal with field contents that contain markup
      * themselves.
      *
-     * @param \Solarium\QueryType\Select\Query\Query $query
      * @param array $arguments request arguments
      */
     protected function addHighlighting($arguments)
@@ -720,7 +703,6 @@ class SolrServiceProvider implements ServiceProviderInterface
      * Adds feedback about invalid sort string format to the page.
      *
      * @param string $sortString
-     * @param $query
      */
     protected function addSortStringForQuery($sortString)
     {
@@ -753,6 +735,7 @@ class SolrServiceProvider implements ServiceProviderInterface
 
     /**
      * Main starting point for blank index action
+     *
      * @return array
      */
     public function getDefaultQuery()
@@ -865,7 +848,6 @@ class SolrServiceProvider implements ServiceProviderInterface
     /**
      * Adds filter queries configured in TypoScript to $query.
      *
-     * @param \Solarium\QueryType\Select\Query\Query $query
      * @return $this
      */
     protected function addTypoScriptFilters()
@@ -1036,22 +1018,6 @@ class SolrServiceProvider implements ServiceProviderInterface
     }
 
     /**
-     * @return array
-     */
-    public function getRequestArguments()
-    {
-        return $this->requestArguments;
-    }
-
-    /**
-     * @param array $requestArguments
-     */
-    public function setRequestArguments($requestArguments)
-    {
-        $this->requestArguments = $requestArguments;
-    }
-
-    /**
      * @return string
      */
     protected function getAction()
@@ -1118,7 +1084,6 @@ class SolrServiceProvider implements ServiceProviderInterface
     /**
      * @param $id
      * @param $assignments
-     * @param $arguments
      * @return mixed
      */
     protected function getTheRecordSpecified($id, $assignments)

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -1,26 +1,42 @@
 plugin.tx_find {
-	settings {
-		connection {
-			host = 127.0.0.1
-			port = 8080
-			path = /solr/
-			timeout = 5
-			scheme = http
-		}
-		count = 20
-		 # cat=plugin.tx_find/file; type=string; label=Path to CSS file (FE)
-		CSSPath = EXT:find/Resources/Public/CSS/find.css
-		 # cat=plugin.tx_find/file; type=string; label=Path to JavaScript file (FE)
-		JSPath = EXT:find/Resources/Public/JavaScript/find.js
-		 # cat=plugin.tx_find/file; type=string; label=Path to template localisation files (FE)
-		languageRootPath = EXT:find/Resources/Private/Language/
-	}
-	view {
-		 # cat=plugin.tx_find/file; type=string; label=Path to template root (FE)
-		templateRootPath = EXT:find/Resources/Private/Templates/
-		 # cat=plugin.tx_find/file; type=string; label=Path to template partials (FE)
-		partialRootPath = EXT:find/Resources/Private/Partials/
-		 # cat=plugin.tx_find/file; type=string; label=Path to template layouts (FE)
-		layoutRootPath = EXT:find/Resources/Private/Layouts/
-	}
+    settings {
+        # cat=plugin.tx_find/provider; type=string; label=Active search connection
+        activeConnection = default
+
+        connections {
+            default {
+                # cat=plugin.tx_find/connections/default; type=string; label=Default Service Provider
+                provider = Subugoe\Find\Service\SolrServiceProvider
+                options {
+                    # cat=plugin.tx_find/connections/default; type=string; label=Solr Host
+                    host = 127.0.0.1
+                    # cat=plugin.tx_find/connections/default; type=int+; label=Solr Port
+                    port = 8080
+                    # cat=plugin.tx_find/connections/default; type=string; label=Path to the solr core in use
+                    path = /solr/mycore
+                    # cat=plugin.tx_find/connections/default; type=int+; label=Solr Connection Timeout
+                    timeout = 5
+                    # cat=plugin.tx_find/connections/default; type=string; label=Solr Connection Scheme
+                    scheme = http
+                }
+            }
+        }
+
+        count = 20
+        # cat=plugin.tx_find/file; type=string; label=Path to CSS file (FE)
+        CSSPath = EXT:find/Resources/Public/CSS/find.css
+        # cat=plugin.tx_find/file; type=string; label=Path to JavaScript file (FE)
+        JSPath = EXT:find/Resources/Public/JavaScript/find.js
+        # cat=plugin.tx_find/file; type=string; label=Path to template localisation files (FE)
+        languageRootPath = EXT:find/Resources/Private/Language/
+    }
+
+    view {
+        # cat=plugin.tx_find/file; type=string; label=Path to template root (FE)
+        templateRootPath = EXT:find/Resources/Private/Templates/
+        # cat=plugin.tx_find/file; type=string; label=Path to template partials (FE)
+        partialRootPath = EXT:find/Resources/Private/Partials/
+        # cat=plugin.tx_find/file; type=string; label=Path to template layouts (FE)
+        layoutRootPath = EXT:find/Resources/Private/Layouts/
+    }
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,245 +1,253 @@
 plugin.tx_find {
-	settings {
-		connection {
-			host = {$plugin.tx_find.settings.connection.host}
-			port = {$plugin.tx_find.settings.connection.port}
-			path = {$plugin.tx_find.settings.connection.path}
-			timeout = {$plugin.tx_find.settings.connection.timeout}
-			scheme = {$plugin.tx_find.settings.connection.scheme}
-		}
+    settings {
+        activeConnection = {$plugin.tx_find.settings.activeConnection}
+        connections {
+            default {
+                provider = {$plugin.tx_find.settings.connections.default.provider}
+                options {
+                    host = {$plugin.tx_find.settings.connections.default.options.host}
+                    port = {$plugin.tx_find.settings.connections.default.options.port}
+                    path = {$plugin.tx_find.settings.connections.default.options.path}
+                    timeout = {$plugin.tx_find.settings.connections.default.options.timeout}
+                    scheme = {$plugin.tx_find.settings.connections.default.options.scheme}
+                }
+            }
+        }
 
-		queryFields {
-			0 {
-				id = default
-				query = %s
-				type = Text
-				#    autocomplete = 1
-				#    autocompleteDictionary =
-			}
+        queryFields {
+            0 {
+                id = default
+                query = %s
+                type = Text
+                #    autocomplete = 1
+                #    autocompleteDictionary =
+            }
 
-			#10 {
-			#    id = person
-			#    extended = 1
-			#    type = Text
-			#}
-			#11 {
-			#    id = notperson
-			#    extended = 1
-			#    query = NOT person:%s
-			#    type = Text
-			#}
-			#12 {
-			#    id = personlastname
-			#    extended = 1
-			#    query = person:%s
-			#    queryAlternate.1 = lastname:%s
-			#    type = Text
-			#}
-			#30 {
-			#    id = country
-			#    extended = 1
-			#    type = Select
-			#    options {
-			#        blank =
-			#        key = value
-			#        key2 = value2
-			#    }
-			#    default = key
-			#}
-			#40 {
-			#    id = version
-			#    extended = 1
-			#    type = Radio
-			#    options {
-			#        1 = Steak
-			#        2 = Chicken
-			#        3 = Pancake
-			#    }
-			#    default = 1
-			#}
-			#50 {
-			#    id = dateRange
-			#    type = Range
-			#    query = year_from:[* TO %2$s] AND year_to:[%1$s TO *]
-			#    default.0 = *
-			#    default.1 = *
-			#    noescape = 1
-			#    extended = 1
-			#}
-			#60 {
-			#    id = status
-			#    type = SelectFacet
-			#    facetID = status
-			#    extended = 1
-			#}
-			10001 {
-				id = extended
-				type = Hidden
-			}
+            #10 {
+            #    id = person
+            #    extended = 1
+            #    type = Text
+            #}
+            #11 {
+            #    id = notperson
+            #    extended = 1
+            #    query = NOT person:%s
+            #    type = Text
+            #}
+            #12 {
+            #    id = personlastname
+            #    extended = 1
+            #    query = person:%s
+            #    queryAlternate.1 = lastname:%s
+            #    type = Text
+            #}
+            #30 {
+            #    id = country
+            #    extended = 1
+            #    type = Select
+            #    options {
+            #        blank =
+            #        key = value
+            #        key2 = value2
+            #    }
+            #    default = key
+            #}
+            #40 {
+            #    id = version
+            #    extended = 1
+            #    type = Radio
+            #    options {
+            #        1 = Steak
+            #        2 = Chicken
+            #        3 = Pancake
+            #    }
+            #    default = 1
+            #}
+            #50 {
+            #    id = dateRange
+            #    type = Range
+            #    query = year_from:[* TO %2$s] AND year_to:[%1$s TO *]
+            #    default.0 = *
+            #    default.1 = *
+            #    noescape = 1
+            #    extended = 1
+            #}
+            #60 {
+            #    id = status
+            #    type = SelectFacet
+            #    facetID = status
+            #    extended = 1
+            #}
+            10001 {
+                id = extended
+                type = Hidden
+            }
 
-			10002 {
-				id = raw
-				query = %s
-				noescape = 1
-				hidden = 1
-				type = Text
-			}
-		}
+            10002 {
+                id = raw
+                query = %s
+                noescape = 1
+                hidden = 1
+                type = Text
+            }
+        }
 
-		defaultQuery = *:*
-		dataFields {
-			default {
-				default {
-					# when setting the fields explicitly, do not forget including the id field if you need to do anything related to the document
-					# f0 = id
-					# f1 = name
-				}
+        defaultQuery = *:*
+        dataFields {
+            default {
+                default {
+                    # when setting the fields explicitly, do not forget including the id field if you need to do anything related to the document
+                    # f0 = id
+                    # f1 = name
+                }
 
-				allow {
+                allow {
 
-				}
+                }
 
-				disallow {
+                disallow {
 
-				}
-			}
+                }
+            }
 
-			# index {
-			#    default {
-			#    }
-			#    allow {
-			#    }
-			#    disallow {
-			#    }
-			# }
-		}
+            # index {
+            #    default {
+            #    }
+            #    allow {
+            #    }
+            #    disallow {
+            #    }
+            # }
+        }
 
-		# Map data field id -> query field id to set up specific searches of field contents
-		queryFieldForDataField {
+        # Map data field id -> query field id to set up specific searches of field contents
+        queryFieldForDataField {
 
-		}
+        }
 
-		sort {
-			#1 {
-			#    id = default
-			#    sortCriteria = year desc,name asc
-			#}
-		}
+        sort {
+            #1 {
+            #    id = default
+            #    sortCriteria = year desc,name asc
+            #}
+        }
 
-		standardFields {
-			title = title
-			snippet = snippet
-		}
+        standardFields {
+            title = title
+            snippet = snippet
+        }
 
-		facets {
-			#10 {
-			#    id = type
-			#    autocomplete = 0
-			#    hidden = 1
-			#}
-			#20 {
-			#    id = year
-			#    field = year_facet
-			#    type = Histogram
-			#    fetchMaximum = 1000
-			#    displayDefault = 1000
-			#    sortOrder = index
-			#    query = year:%s
-			#}
-			#100 {
-			#    id = status
-			#    field = status_facet
-			#    hidden = 1
-			#    fetchMinimum = 0
-			#    fetchMaximum = 1000
-			#}
-		}
+        facets {
+            #10 {
+            #    id = type
+            #    autocomplete = 0
+            #    hidden = 1
+            #}
+            #20 {
+            #    id = year
+            #    field = year_facet
+            #    type = Histogram
+            #    fetchMaximum = 1000
+            #    displayDefault = 1000
+            #    sortOrder = index
+            #    query = year:%s
+            #}
+            #100 {
+            #    id = status
+            #    field = status_facet
+            #    hidden = 1
+            #    fetchMinimum = 0
+            #    fetchMaximum = 1000
+            #}
+        }
 
-		facetDefaults {
-			queryStyle = filter
-			# queryStyle = and
-			fetchMinimum = 1
-			fetchMaximum = 100
-			displayDefault = 6
-			sortOrder = count
-		}
+        facetDefaults {
+            queryStyle = filter
+            # queryStyle = and
+            fetchMinimum = 1
+            fetchMaximum = 100
+            displayDefault = 6
+            sortOrder = count
+        }
 
-		highlight {
-			default {
-				fields.f1 = *
-				fragsize = 100
-				# query = %s
-				# useQueryTerms = 0
-				# useFacetTerms = 0
-				# alternateFields {
-				#    transliteration = transliterationHiglight
-				# }
-			}
+        highlight {
+            default {
+                fields.f1 = *
+                fragsize = 100
+                # query = %s
+                # useQueryTerms = 0
+                # useFacetTerms = 0
+                # alternateFields {
+                #    transliteration = transliterationHiglight
+                # }
+            }
 
-			index {
+            index {
 
-			}
+            }
 
-			detail {
+            detail {
 
-			}
+            }
 
-			data {
+            data {
 
-			}
-		}
+            }
+        }
 
-		additionalFilters {
-			# 1 = type:kloster
-		}
+        additionalFilters {
+            # 1 = type:kloster
+        }
 
-		features {
-			# eDisMax = 1
-		}
+        features {
+            # eDisMax = 1
+        }
 
-		paging {
-			perPage = {$plugin.tx_find.settings.count}
-			menu {
-				#    1 = 10
-				#    2 = 20
-				#    3 = 50
-				#    4 = 100
-			}
+        paging {
+            perPage = {$plugin.tx_find.settings.count}
+            menu {
+                #    1 = 10
+                #    2 = 20
+                #    3 = 50
+                #    4 = 100
+            }
 
-			maximumPerPage = 1000
-			detailPagePaging = 1
-		}
+            maximumPerPage = 1000
+            detailPagePaging = 1
+        }
 
-		jumpToID = tx_find
+        jumpToID = tx_find
 
-		CSSPaths.10 = {$plugin.tx_find.settings.CSSPath}
-		CSSPaths.20 = EXT:find/Resources/Public/CSS/fontello/css/fontello.css
-		JSPaths.10 = {$plugin.tx_find.settings.JSPath}
+        CSSPaths.10 = {$plugin.tx_find.settings.CSSPath}
+        CSSPaths.20 = EXT:find/Resources/Public/CSS/fontello/css/fontello.css
+        JSPaths.10 = {$plugin.tx_find.settings.JSPath}
 
-		languageRootPath = {$plugin.tx_find.settings.languageRootPath}
-	}
+        languageRootPath = {$plugin.tx_find.settings.languageRootPath}
+    }
 
-	view {
-		templateRootPaths {
-			10 = {$plugin.tx_find.view.templateRootPath}
-		}
+    view {
+        templateRootPaths {
+            10 = {$plugin.tx_find.view.templateRootPath}
+        }
 
-		partialRootPaths {
-			10 = {$plugin.tx_find.view.partialRootPath}
-		}
+        partialRootPaths {
+            10 = {$plugin.tx_find.view.partialRootPath}
+        }
 
-		layoutRootPaths {
-			10 = {$plugin.tx_find.view.layoutRootPath}
-		}
-	}
+        layoutRootPaths {
+            10 = {$plugin.tx_find.view.layoutRootPath}
+        }
+    }
 }
+
+module.tx_find.settings < plugin.tx_find.settings
 
 tx_find_page = PAGE
 tx_find_page {
-	typeNum = 1369315139
-	10 < tt_content.list.20.find_find
-	config {
-		disableAllHeaderCode = 1
-		additionalHeaders = Content-type:application/json;charset=utf-8
-	}
+    typeNum = 1369315139
+    10 < tt_content.list.20.find_find
+    config {
+        disableAllHeaderCode = 1
+        additionalHeaders = Content-type:application/json;charset=utf-8
+    }
 }

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -32,13 +32,17 @@ For the most basic example you need to:
 
 #. include the find plug-in’s template in your site/page’s template
 
-#. configure your index information in the TypoScript template for that page. At minimum you should set the address of your Solr index and the fields to display in the result list::
+#. configure your index information in the TypoScript template for that page. At minimum you should set the address of your default Solr index and the fields to display in the result list::
 
 	plugin.tx_find.settings {
-		connection {
-			host = solr.local
-			port = 8080
-			path = /solr/myIndex
+		connections {
+			default {
+				options {
+					host = solr.local
+					port = 8080
+					path = /solr/myIndex
+				}
+			}
 		}
 		standardFields {
 			title = title
@@ -119,7 +123,11 @@ All settings discussed in this section are inside the ``plugin.tx_find.settings`
 Connection to the Solr index
 ::::::::::::::::::::::::::::
 
-The ``connection`` settings array is used to configure access to the Solr index. It contains:
+You can have multiple Solr connections. Every connection needs to use a provider and an options array.
+
+The ``plugin.tx_find.settings.activeConnection`` determines the currently used connection. The default value is ``default``.
+
+The ``options`` settings array in a connection definition is used to configure access to the Solr index. It contains:
 
 * ``host`` [127.0.0.1]: hostname of the server running the index
 * ``port`` [8080]: port of the Solr service on the server
@@ -127,6 +135,22 @@ The ``connection`` settings array is used to configure access to the Solr index.
 * ``timeout`` [5]: number of seconds before a Solr request times out
 * ``scheme`` [http]: URI scheme of the connection
 
+#. Example::
+
+	plugin.tx_find.settings {
+		connections {
+			default {
+				provider = Subugoe\Find\Service\SolrServiceProvider
+				options {
+					host = 127.0.0.1
+					port = 8080
+					path = /solr/
+					timeout = 5
+					scheme = http
+				}
+			}
+		}
+	}
 
 Solr Components
 :::::::::::::::


### PR DESCRIPTION
This change essentially allows to change the Implementation of the Solr search,
by adding greater flexibility to the configuration.

One can now implement `ServiceProviderInterface` and define a custom connection
where the service provider should be used.

Example:

```TypoScript
plugin.tx_find {
    settings {
        activeConnection = alternativeIndexWithSuperPowers
        connections {
            alternativeIndexWithSuperPowers {
                provider = MegaCorp\Foo\Solr\SearchServiceProvider
                options {
                    host = {$plugin.tx_find.settings.connections.default.options.host}
                    port = {$plugin.tx_find.settings.connections.default.options.port}
                    path = {$plugin.tx_find.settings.connections.default.options.path}
                    timeout = {$plugin.tx_find.settings.connections.default.options.timeout}
                    scheme = {$plugin.tx_find.settings.connections.default.options.scheme}
                }
            }
        }
    }
}
```

```php
<?php

namespace MegaCorp\Foo\Solr;

class SearchServiceProvider extends SolrServiceProvider implements ServiceProviderInterface
 {
    /**
     * always return 42 as counter
     */
    protected function counterStart()
    {
        return 42;
    }
}
```

This changeset contains a breaking change, since the typoscript constants and setup were re-arranged
to have a plausible settings structure.