### PR TITLE
Fixed bug on expandable facet lists

### DIFF
--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -41,6 +41,7 @@
 			<label index="remove filter">remove filter</label>
 			<label index="remove filter %s">remove filter “%s”</label>
 			<label index="show all">show all</label>
+			<label index="hide hidden">collapse list</label>
 
 			<label index="Show Detail Page">Details</label>
 

--- a/Resources/Private/Partials/Facets/Facet/List.html
+++ b/Resources/Private/Partials/Facets/Facet/List.html
@@ -30,9 +30,14 @@
 		</f:alias>
 	</f:for>
 	<f:if condition="{f:count(subject:facetData.values)} > {facetInfo.displayDefault}">
-		<li class="facetShowAll">
+		<li class="facetShowAll" style="display: list-item;">
 			<a href="#" onclick="return tx_find.showAllFacetsOfType(event)">
 				<f:translate key="show all"/>
+			</a>
+		</li>
+		<li class="facetHideHidden" style="display: none;">
+			<a href="#" onclick="return tx_find.showAllFacetsOfType(event)">
+				<f:translate key="hide hidden"/>
 			</a>
 		</li>
 	</f:if>

--- a/Resources/Public/CSS/find.css
+++ b/Resources/Public/CSS/find.css
@@ -230,7 +230,14 @@
   font-style: italic;
   color: #666666;
 }
+.tx_find article.facet .facetHideHidden a, .tx_find .facet-type-Tabs .facetHideHidden a {
+  font-style: italic;
+  color: #666666;
+}
 .tx_find article.facet .facetShowAll a:hover, .tx_find .facet-type-Tabs .facetShowAll a:hover {
+  color: black;
+}
+.tx_find article.facet .facetHideHidden a:hover, .tx_find .facet-type-Tabs .facetHideHidden a:hover {
   color: black;
 }
 .tx_find article.facet .facetHistogram-container .facetActive, .tx_find .facet-type-Tabs .facetHistogram-container .facetActive {

--- a/Resources/Public/CSS/find.scss
+++ b/Resources/Public/CSS/find.scss
@@ -309,6 +309,17 @@ $tabSelected: #263476;
             }
         }
 
+        .facetHideHidden {
+            a {
+                font-style: italic;
+                color: $downlight;
+            }
+
+            a:hover {
+                color: $current;
+            }
+        }
+
         .facetHistogram-container .facetActive {
             margin-bottom: 0.5em;
         }

--- a/Resources/Public/JavaScript/find.js
+++ b/Resources/Public/JavaScript/find.js
@@ -107,12 +107,23 @@ var tx_find = (function () {
    * @param {Event} myEvent click event
    * @returns {Boolean} false
    */
+   */
   var showAllFacetsOfType = function (myEvent) {
-    var jLink = jQuery(myEvent.toElement);
+    var jLink = jQuery(myEvent.target);
     var containingList = jLink.parents('ol')[0];
+    var linkShowAll = jQuery('.facetShowAll', containingList);
+    var linkHideHidden = jQuery('.facetHideHidden', containingList);
     // Fade in the hidden elemens and hide the Show All link.
-    jQuery('.hidden', containingList).slideDown(300);
-    jLink.parent().fadeOut(200);
+    jQuery('.hidden', containingList).slideToggle(500);
+    // Check links to show all or hide previously hidden elements and toggle css style attribute 'display'
+    if ( $(linkShowAll).is(":hidden") ) {
+      jQuery(linkShowAll).show();
+      jQuery(linkHideHidden).hide();
+    }
+    else {
+      jQuery(linkShowAll).hide();
+      jQuery(linkHideHidden).show();
+    }
     return false;
   };
 


### PR DESCRIPTION
With this fix only the desired facet list will be expanded (Closes #132).

Furthermore this adds the functionality to collapse expanded lists instead of just having the "show-all" link disappear. Translation of link text has been added to locallang.xml.