### PR TITLE
Use f:format.raw on highlighted content of non-linked fields as well

### DIFF
--- a/Resources/Private/Partials/Display/Field/Content.html
+++ b/Resources/Private/Partials/Display/Field/Content.html
@@ -81,12 +81,14 @@
 		</f:alias>
 	</f:then>
 	<f:else>
-		<s:find.highlightField
-			field="{field}"
-			document="{document}"
-			results="{results}"
-			index="{iterator.index}"
-			alternateField="{s:data.valueForKey(array:config.highlight.alternateFields, key:field)}"
-		/>
+		<f:format.raw>
+			<s:find.highlightField
+				field="{field}"
+				document="{document}"
+				results="{results}"
+				index="{iterator.index}"
+				alternateField="{s:data.valueForKey(array:config.highlight.alternateFields, key:field)}"
+			/>
+		</f:format.raw>
 	</f:else>
 </f:if>


### PR DESCRIPTION
Output is escaped twice in TYPO3 9.5 otherwise.

(Seeing that the string in the <f:then> is also
rendered using f:format.raw, it seems plausible
that the issue exists in earlier versions as well.)