### PR TITLE
Fix TYPO3 version incompatibility

### DIFF
--- a/Classes/ViewHelpers/Page/LinkCSSViewHelper.php
+++ b/Classes/ViewHelpers/Page/LinkCSSViewHelper.php
@@ -30,7 +30,6 @@ namespace Subugoe\Find\ViewHelpers\Page;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
-use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -66,7 +65,7 @@ class LinkCSSViewHelper extends AbstractViewHelper
         } else {
             $fileNameFromArguments = $arguments['file'];
             if ($fileNameFromArguments) {
-                $CSSFileName = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
+                $CSSFileName = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Resource\FilePathSanitizer::class)->sanitize($fileNameFromArguments);
             }
         }
 

--- a/Classes/ViewHelpers/Page/LinkCSSViewHelper.php
+++ b/Classes/ViewHelpers/Page/LinkCSSViewHelper.php
@@ -59,21 +59,20 @@ class LinkCSSViewHelper extends AbstractViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $typo3VersionConstraint = version_compare(VersionNumberUtility::getNumericTypo3Version(), '10.0.0', '<');
+        $typo3VersionConstraint = version_compare(VersionNumberUtility::getNumericTypo3Version(), '9.5.0', '<');
 
         if ($typo3VersionConstraint) {
             $CSSFileName = $GLOBALS['TSFE']->tmpl->getFileName($arguments['file']);
-            if ($CSSFileName) {
-                $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-                $pageRenderer->addCSSFile($CSSFileName);
-            }
         } else {
             $fileNameFromArguments = $arguments['file'];
             if ($fileNameFromArguments) {
                 $CSSFileName = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
-                $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-                $pageRenderer->addCSSFile($CSSFileName);
             }
+        }
+
+        if ($CSSFileName) {
+            $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+            $pageRenderer->addCSSFile($CSSFileName);
         }
     }
 }

--- a/Classes/ViewHelpers/Page/LinkCSSViewHelper.php
+++ b/Classes/ViewHelpers/Page/LinkCSSViewHelper.php
@@ -29,6 +29,7 @@ namespace Subugoe\Find\ViewHelpers\Page;
 
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -58,11 +59,21 @@ class LinkCSSViewHelper extends AbstractViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $fileNameFromArguments = $arguments['file'];
-        if ($fileNameFromArguments) {
-            $CSSFileName = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
-            $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-            $pageRenderer->addCSSFile($CSSFileName);
+        $typo3VersionConstraint = version_compare(VersionNumberUtility::getNumericTypo3Version(), '10.0.0', '<');
+
+        if ($typo3VersionConstraint) {
+            $CSSFileName = $GLOBALS['TSFE']->tmpl->getFileName($arguments['file']);
+            if ($CSSFileName) {
+                $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+                $pageRenderer->addCSSFile($CSSFileName);
+            }
+        } else {
+            $fileNameFromArguments = $arguments['file'];
+            if ($fileNameFromArguments) {
+                $CSSFileName = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
+                $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+                $pageRenderer->addCSSFile($CSSFileName);
+            }
         }
     }
 }

--- a/Classes/ViewHelpers/Page/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/Page/ScriptViewHelper.php
@@ -26,6 +26,7 @@ namespace Subugoe\Find\ViewHelpers\Page;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -73,17 +74,28 @@ class ScriptViewHelper extends AbstractViewHelper
     ) {
         $name = $arguments['name'];
         $pageRenderer = self::getPageRenderer();
-        
-        $fileNameFromArguments = $arguments['file'];
-        if ($fileNameFromArguments) {
-            $scriptPath = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
-            $pageRenderer->addJsFooterLibrary($name, $scriptPath);
-        }
-        else {
+
+        $typo3VersionConstraint = version_compare(VersionNumberUtility::getNumericTypo3Version(), '10.0.0', '<');
+
+        if ($typo3VersionConstraint) {
+            $scriptPath = static::getTypoScriptTemplateService()->getFileName($arguments['file']);
+            if ($scriptPath) {
+                $pageRenderer->addJsFooterLibrary($name, $scriptPath);
+                return '';
+            }
             $content = $renderChildrenClosure();
             $pageRenderer->addJsFooterInlineCode($name, $content);
+            return '';
+        } else {
+            if ($fileNameFromArguments) {
+                $scriptPath = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
+                $pageRenderer->addJsFooterLibrary($name, $scriptPath);
+            }
+            else {
+                $content = $renderChildrenClosure();
+                $pageRenderer->addJsFooterInlineCode($name, $content);
+            }
+            return '';
         }
-
-        return '';
     }
 }

--- a/Classes/ViewHelpers/Page/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/Page/ScriptViewHelper.php
@@ -27,7 +27,6 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
-use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
@@ -92,7 +91,7 @@ class ScriptViewHelper extends AbstractViewHelper
         } else {
             $fileNameFromArguments = $arguments['file'];
             if ($fileNameFromArguments) {
-                $scriptPath = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
+                $scriptPath = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Resource\FilePathSanitizer::class)->sanitize($fileNameFromArguments);
                 $pageRenderer->addJsFooterLibrary($name, $scriptPath);
             }
             else {

--- a/Classes/ViewHelpers/Page/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/Page/ScriptViewHelper.php
@@ -75,18 +75,22 @@ class ScriptViewHelper extends AbstractViewHelper
         $name = $arguments['name'];
         $pageRenderer = self::getPageRenderer();
 
-        $typo3VersionConstraint = version_compare(VersionNumberUtility::getNumericTypo3Version(), '10.0.0', '<');
+        $typo3VersionConstraint = version_compare(VersionNumberUtility::getNumericTypo3Version(), '9.5.0', '<');
 
         if ($typo3VersionConstraint) {
             $scriptPath = static::getTypoScriptTemplateService()->getFileName($arguments['file']);
+
             if ($scriptPath) {
                 $pageRenderer->addJsFooterLibrary($name, $scriptPath);
                 return '';
             }
+
             $content = $renderChildrenClosure();
             $pageRenderer->addJsFooterInlineCode($name, $content);
+
             return '';
         } else {
+            $fileNameFromArguments = $arguments['file'];
             if ($fileNameFromArguments) {
                 $scriptPath = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($fileNameFromArguments);
                 $pageRenderer->addJsFooterLibrary($name, $scriptPath);

--- a/Resources/Public/JavaScript/find.js
+++ b/Resources/Public/JavaScript/find.js
@@ -107,7 +107,6 @@ var tx_find = (function () {
    * @param {Event} myEvent click event
    * @returns {Boolean} false
    */
-*/
   var showAllFacetsOfType = function (myEvent) {
     var jLink = jQuery(myEvent.target);
     var containingList = jLink.parents('ol')[0];


### PR DESCRIPTION
TYPO3 v8 doesn't contain FilePathSanitizer in sysext frontend which "find" was prepared to use from v10 upwards in #144. This commit adds a version check and makes find available in installations with versions lower than v10.