### PR TITLE
Added missing translation

### DIFF
--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -83,6 +83,7 @@
 			<label index="remove filter">Filter aufheben</label>
 			<label index="remove filter %s">Filter „%s“ aufheben</label>
 			<label index="show all">alle zeigen</label>
+			<label index="hide hidden">Liste einklappen</label>
 
 			<label index="Show Detail Page">Details</label>
 


### PR DESCRIPTION
Added missing german translation for the key "hide hidden" at the bottom of facet term lists.