### PR TITLE
Fix bug of always expanding extended search form

### DIFF
--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -490,8 +490,18 @@ class SolrServiceProvider extends AbstractServiceProvider implements ServiceProv
                         && array_key_exists($fieldInfo['id'], $this->requestArguments['q'])
                         && $this->requestArguments['q'][$fieldInfo['id']]
                     ) {
-                        $result = true;
-                        break;
+                        // Check if the request argument is an array itself (appies to field type "Range")
+                        if (is_array($this->requestArguments['q'][$fieldInfo['id']])) {
+                            foreach ($this->requestArguments['q'][$fieldInfo['id']] as $key => $value) {
+                                if ($value !== "") {
+                                    $result = true;
+                                    break;
+                                }
+                            }
+                        } else {
+                            $result = true;
+                            break;
+                        }
                     }
                 }
             }

--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -493,7 +493,7 @@ class SolrServiceProvider extends AbstractServiceProvider implements ServiceProv
                         // Check if the request argument is an array itself (appies to field type "Range")
                         if (is_array($this->requestArguments['q'][$fieldInfo['id']])) {
                             foreach ($this->requestArguments['q'][$fieldInfo['id']] as $key => $value) {
-                                if ($value !== "") {
+                                if ('' !== $value) {
                                     $result = true;
                                     break;
                                 }

--- a/Classes/ViewHelpers/Page/ScriptViewHelper.php
+++ b/Classes/ViewHelpers/Page/ScriptViewHelper.php
@@ -81,6 +81,7 @@ class ScriptViewHelper extends AbstractViewHelper
 
             if ($scriptPath) {
                 $pageRenderer->addJsFooterLibrary($name, $scriptPath);
+
                 return '';
             }
 
@@ -93,11 +94,11 @@ class ScriptViewHelper extends AbstractViewHelper
             if ($fileNameFromArguments) {
                 $scriptPath = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Resource\FilePathSanitizer::class)->sanitize($fileNameFromArguments);
                 $pageRenderer->addJsFooterLibrary($name, $scriptPath);
-            }
-            else {
+            } else {
                 $content = $renderChildrenClosure();
                 $pageRenderer->addJsFooterInlineCode($name, $content);
             }
+
             return '';
         }
     }


### PR DESCRIPTION
The check if request arguments are used depending on whether they exist does not work for the field type "Range" because the result will always be "Array" and the request argument check will therefore always be evaluated as true. That's why the extended search will expand with every simple search if the find-setup contains at least one field of the type "Range". 
This addition also checks the array fields of range fields if they are empty and therefore not used.