### PR TITLE
Add basic Solr 8 compatibility

### DIFF
--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -1042,11 +1042,17 @@ class SolrServiceProvider extends AbstractServiceProvider
 
                 ksort($queryTerms);
 
+                if ($this->settings['luceneMatchVersion'] < 8) {
+                    $magicFieldPrefix = '_query_:';
+                } else {
+                    $magicFieldPrefix = '';
+                }
+
                 if ($this->settings['features']['eDisMax']) {
-                    $queryPart = '_query_:{!edismax}'.$this->query->getHelper()->escapePhrase(vsprintf($queryFormat, $queryTerms));
+                    $queryPart = $magicFieldPrefix.'{!edismax}'.$this->query->getHelper()->escapePhrase(vsprintf($queryFormat, $queryTerms));
                     $queryPart = str_replace('"', '', $queryPart);
                 } else {
-                    $queryPart = '_query_:'.$this->query->getHelper()->escapePhrase(vsprintf($queryFormat, $queryTerms));
+                    $queryPart = $magicFieldPrefix.$this->query->getHelper()->escapePhrase(vsprintf($queryFormat, $queryTerms));
                 }
 
                 if ($queryPart) {

--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -1042,10 +1042,10 @@ class SolrServiceProvider extends AbstractServiceProvider
 
                 ksort($queryTerms);
 
-                if ($this->settings['luceneMatchVersion'] < 8) {
+                $magicFieldPrefix = '';
+
+                if ((int) $this->settings['luceneMatchVersion'] < 8) {
                     $magicFieldPrefix = '_query_:';
-                } else {
-                    $magicFieldPrefix = '';
                 }
 
                 if ($this->settings['features']['eDisMax']) {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,5 +1,6 @@
 plugin.tx_find {
     settings {
+        luceneMatchVersion = 8
         activeConnection = {$plugin.tx_find.settings.activeConnection}
         connections {
             default {

--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ When using the eDisMax feature solr offers, add
 
 -   `features.eDisMax = 1`
 
+In case the Solr version is lower than 8, the setting
+`plugin.tx_find.settings.luceneMatchVersion` has to be set to the major version
+that is used (for instance 6 or 7). By default this is set to 8 and affects
+a magic query prefix (see https://lucene.apache.org/solr/guide/6_6/the-extended-dismax-query-parser.html#TheExtendedDisMaxQueryParser-Usingthe_magicfields__val_and_query_).
+
 ### The search form
 
 The `queryFields` setting configures the search form. It is a numbered


### PR DESCRIPTION
This addition is necessary if you want to use Solr >8 and cannot alter the luceneMatchVersion in your solrconfig.xml because at least since Solr 8 nested queries won't accept the magic field trick with `_query_` anymore.

To try it out with a Solr 8 you have to add the following to your tx_find plugin's "setup.typoscript": 
`plugin.tx_find.settings.luceneMatchVersion = 8`

For comparison with earlier Solr versions you can set the value according to your actual Solr configuration in solrconfig.xml.