### PR TITLE
Solr endpoint authentication

### DIFF
--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -79,7 +79,11 @@ class SolrServiceProvider extends AbstractServiceProvider
             ],
         ];
 
-        $this->setConnection(new Client($connectionSettings));
+        $client = new Client($connectionSettings);
+        if ($currentConnectionSettings['username'] && $currentConnectionSettings['password']) {
+            $client->getEndpoint()->setAuthentication($currentConnectionSettings['username'], $currentConnectionSettings['password']);
+        }
+        $this->setConnection($client);
     }
 
     /**

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -18,6 +18,10 @@ plugin.tx_find {
                     timeout = 5
                     # cat=plugin.tx_find/connections/default; type=string; label=Solr Connection Scheme
                     scheme = http
+                    # cat=plugin.tx_find/connections/default; type=string; label=Solr Connection Username
+                    username =
+                    # cat=plugin.tx_find/connections/default; type=string; label=Solr Connection Password
+                    password =
                 }
             }
         }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -12,6 +12,8 @@ plugin.tx_find {
                     path = {$plugin.tx_find.settings.connections.default.options.path}
                     timeout = {$plugin.tx_find.settings.connections.default.options.timeout}
                     scheme = {$plugin.tx_find.settings.connections.default.options.scheme}
+                    username = {$plugin.tx_find.settings.connections.default.options.username}
+                    password = {$plugin.tx_find.settings.connections.default.options.password}
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ configure access to the Solr index. It contains:
 -   `path` \[/solr/\]: path of the Index on the Solr server
 -   `timeout` \[5\]: number of seconds before a Solr request times out
 -   `scheme` \[http\]: URI scheme of the connection
+-   `username` \[]: Username in case you Basic Auth secured your Solr via .htaccess
+-   `password` \[]: Password in case you Basic Auth secured your Solr via .htaccess
 
 1.  Example:
     ```
@@ -172,6 +174,8 @@ configure access to the Solr index. It contains:
                     path = /solr/
                     timeout = 5
                     scheme = http
+                    username =
+                    password =
                 }
             }
         }


### PR DESCRIPTION
With the changes in this PR we add Solr endpoint authentication to let users configure username and password in case their Solr endpoint has been Basic Auth secured via `.htaccess`.