### PR TITLE
Add facet option (solr missing)

### DIFF
--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -102,7 +102,8 @@ class SolrServiceProvider extends AbstractServiceProvider
         try {
             $resultSet = $this->connection->execute($this->query);
         } catch (HttpException $httpException) {
-            $this->logger->error('Solr Exception (Timeout?)',
+            $this->logger->error(
+                'Solr Exception (Timeout?)',
                 [
                     'requestArguments' => $this->getRequestArguments(),
                     'exception' => LoggerUtility::exceptionToArray($httpException),
@@ -299,12 +300,11 @@ class SolrServiceProvider extends AbstractServiceProvider
                     // set solr query to exclude all known facet values
                     if ($facetTerm === $facetInfo['config']['labelMissing']) {
                         $this->query->createFilterQuery($queryInfo)
-                            ->setQuery("-".str_replace('("%s")','[* TO *]', $facetInfo['config']['query']));
+                            ->setQuery("-".str_replace('("%s")', '[* TO *]', $facetInfo['config']['query']));
                     } else {
                         $this->query->createFilterQuery($queryInfo)
                             ->setQuery($facetQuery);
                     }
-
                 }
 
                 $activeFacetsForTemplate[$facetID][$facetTerm] = $facetInfo;
@@ -339,7 +339,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                             if (array_key_exists('id', $facetQuery) && array_key_exists('query', $facetQuery)) {
                                 $queryForFacet->createQuery($facetQuery['id'], $facetQuery['query']);
                             } else {
-                                $this->logger->error(sprintf('TypoScript facet »%s«, facetQuery %s does not have the required keys »id« and »query«. Ignoring this facetQuery.', $facetID, $facetQueryIndex),
+                                $this->logger->error(
+                                    sprintf('TypoScript facet »%s«, facetQuery %s does not have the required keys »id« and »query«. Ignoring this facetQuery.', $facetID, $facetQueryIndex),
                                     [
                                         'facetQuery' => $facetQuery,
                                         'facetConfiguration' => $facetConfiguration,
@@ -366,9 +367,9 @@ class SolrServiceProvider extends AbstractServiceProvider
                     if ($facet['showMissing'] === 1) {
                         $queryForFacet->setMissing(true);
                     }
-
                 } else {
-                    $this->logger->warning(sprintf('TypoScript facet %s does not have the required key »id«. Ignoring this facet.', $key),
+                    $this->logger->warning(
+                        sprintf('TypoScript facet %s does not have the required key »id«. Ignoring this facet.', $key),
                         [
                             'facet' => $facet,
                             'facetConfiguration' => $facetConfiguration,
@@ -413,8 +414,10 @@ class SolrServiceProvider extends AbstractServiceProvider
                         if ($fieldID && $queryParameters[$fieldID]) {
                             $queryArguments = $queryParameters[$fieldID];
                             $queryTerms = null;
-                            if (is_array($queryArguments) && array_key_exists('alternate',
-                                $queryArguments) && array_key_exists('queryAlternate', $fieldInfo)
+                            if (is_array($queryArguments) && array_key_exists(
+                                'alternate',
+                                $queryArguments
+                            ) && array_key_exists('queryAlternate', $fieldInfo)
                             ) {
                                 if (array_key_exists('term', $queryArguments)) {
                                     $queryTerms = $queryArguments['term'];
@@ -552,7 +555,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                         $sortOptions['default'] = $sortOption['sortCriteria'];
                     }
                 } else {
-                    $this->logger->warning(sprintf('TypoScript sort option »%s« does not have the required keys »id« and »sortCriteria. Ignoring this setting.', $sortOptionIndex),
+                    $this->logger->warning(
+                        sprintf('TypoScript sort option »%s« does not have the required keys »id« and »sortCriteria. Ignoring this setting.', $sortOptionIndex),
                         [
                             'sortOption' => $sortOption,
                         ]
@@ -805,7 +809,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                 }
 
                 if (null === $queryString) {
-                    $this->logger->info(sprintf('Results for Facet »%s« with facetQuery ID »%s« were requested, but this facetQuery is not configured. Building a generic facet query instead.', $facetConfig['id'], $queryTerm),
+                    $this->logger->info(
+                        sprintf('Results for Facet »%s« with facetQuery ID »%s« were requested, but this facetQuery is not configured. Building a generic facet query instead.', $facetConfig['id'], $queryTerm),
                         [
                             'requestArguments' => $this->requestArguments,
                             'facetConfig' => $facetConfig,
@@ -829,7 +834,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                 $queryString = sprintf($queryPattern, $queryTerm);
             }
         } else {
-            $this->logger->warning('A non-configured facet was selected. Ignoring it.',
+            $this->logger->warning(
+                'A non-configured facet was selected. Ignoring it.',
                 ['requestArguments' => $this->requestArguments]
             );
         }
@@ -892,7 +898,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                         $assignments['document-next-number'] = $index['nextIndex'] + 1;
                     }
                 } else {
-                    $this->logger->error(sprintf('»detail« action query with underlying query could not retrieve record id »%d«.', $id),
+                    $this->logger->error(
+                        sprintf('»detail« action query with underlying query could not retrieve record id »%d«.', $id),
                         ['arguments' => $arguments]
                     );
                 }
@@ -900,7 +907,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                 $this->logger->error('»detail« action query with underlying query returned no results.', ['arguments' => $arguments]);
             }
         } catch (HttpException $httpException) {
-            $this->logger->error('Solr Exception (Timeout?)',
+            $this->logger->error(
+                'Solr Exception (Timeout?)',
                 [
                     'arguments' => $arguments,
                     'exception' => LoggerUtility::exceptionToArray($httpException),
@@ -936,7 +944,8 @@ class SolrServiceProvider extends AbstractServiceProvider
                 $this->logger->error(sprintf('»detail« action query for id »%d« returned no results.', $id), ['arguments' => $this->getRequestArguments()]);
             }
         } catch (HttpException $httpException) {
-            $this->logger->error('Solr Exception (Timeout?)',
+            $this->logger->error(
+                'Solr Exception (Timeout?)',
                 [
                     'arguments' => $this->getRequestArguments(),
                     'exception' => LoggerUtility::exceptionToArray($httpException),

--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -303,7 +303,7 @@ class SolrServiceProvider extends AbstractServiceProvider
 
                     // If facet.missing is active and facet is selected
                     // set solr query to exclude all known facet values
-                    if ($facetTerm == $facetInfo['config']['labelmissing']) {
+                    if ($facetTerm === $facetInfo['config']['labelMissing']) {
                         $this->query->createFilterQuery($queryInfo)
                             ->setQuery("-".str_replace('("%s")','[* TO *]', $facetInfo['config']['query']));
                     } else {
@@ -365,7 +365,7 @@ class SolrServiceProvider extends AbstractServiceProvider
                         $queryForFacet->addExclude($this->tagForFacet($facetID));
                     }
 
-                    if ($facet['showmissing'] == 1) {
+                    if ($facet['showMissing'] === 1) {
                         $queryForFacet->setMissing(true);
                     }
                 } else {

--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -300,7 +300,7 @@ class SolrServiceProvider extends AbstractServiceProvider
                     // set solr query to exclude all known facet values
                     if ($facetTerm === $facetInfo['config']['labelMissing']) {
                         $this->query->createFilterQuery($queryInfo)
-                            ->setQuery("-".str_replace('("%s")', '[* TO *]', $facetInfo['config']['query']));
+                            ->setQuery('-'.str_replace('("%s")', '[* TO *]', $facetInfo['config']['query']));
                     } else {
                         $this->query->createFilterQuery($queryInfo)
                             ->setQuery($facetQuery);
@@ -310,6 +310,7 @@ class SolrServiceProvider extends AbstractServiceProvider
                 $activeFacetsForTemplate[$facetID][$facetTerm] = $facetInfo;
             }
         }
+
         return $activeFacetsForTemplate;
     }
 
@@ -364,7 +365,7 @@ class SolrServiceProvider extends AbstractServiceProvider
                         $queryForFacet->addExclude($this->tagForFacet($facetID));
                     }
 
-                    if ($facet['showMissing'] === 1) {
+                    if (1 === $facet['showMissing']) {
                         $queryForFacet->setMissing(true);
                     }
                 } else {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -160,6 +160,8 @@ plugin.tx_find {
             #    hidden = 1
             #    fetchMinimum = 0
             #    fetchMaximum = 1000
+            #    showMissing = 1
+            #    labelMissing = label
             #}
         }
 

--- a/README.md
+++ b/README.md
@@ -403,34 +403,36 @@ plugin.tx_find.settings {
 Faceting can be configured in TypoScript using the `facets` setting. It
 is a numbered list of arrays. Each array can have the keys:
 
--   `id` (required): ID used to identify the facet
--   `type` \[List\]: the type of facet to use (see below for the types
+- `id` (required): ID used to identify the facet
+- `type` \[List\]: the type of facet to use (see below for the types
     provided by the extension)
--   `field`: the Solr field to use for the facet, if not given the field
+- `field`: the Solr field to use for the facet, if not given the field
     given by the `id` will be used
--   `sortOrder` \[count\]: using `index` gives alphabetically sorted
+- `sortOrder` \[count\]: using `index` gives alphabetically sorted
     facet entries, by default facet items are sorted by the number of
     results
--   `fetchMinimum` \[1\]: the minimum number of facet entries needed to
+- `fetchMinimum` \[1\]: the minimum number of facet entries needed to
     display the facet; the facet will not be shown at all if there are
     fewer entries than this
--   `fetchMaximum` \[100\]: the maximum number of facet entries to load
--   `query`: sprintf style formatted string to use as a filter query if
+- `fetchMaximum` \[100\]: the maximum number of facet entries to load
+- `query`: sprintf style formatted string to use as a filter query if
     the facet is selected; by default the facet’s field is used with the
     selected term
--   `facetQuery`: array of facet query configuration arrays to use for
+- `facetQuery`: array of facet query configuration arrays to use for
     creating specific facets; each of the arrays has the keys `id` to
     identify the facet query and `query` the Solr query to create the
     facet for
--   `selectedByDefault`: array with keys field value and values 1 to
+- `selectedByDefault`: array with keys field value and values 1 to
     indicate facet terms that should be selected when no facet selection
     is given (especially useful with the `Tabs` facet type.
--   `excludeOwnFilter` \[0\]: if set to 1 the filters created by the
+- `excludeOwnFilter` \[0\]: if set to 1 the filters created by the
     facet itself will not be used when computing the result count for
     its items
--   `hidden` \[0\]: whether to hide the facet from display (e.g. to use
+- `hidden` \[0\]: whether to hide the facet from display (e.g. to use
     the facet data in some other part of the page like a `SelectFacet`
     query field)
+- `showMissing`\[0\]: If set to 1 the facet shows an item for documents with missing values
+- `labelMissing`: Set own label for the missing facet item
 
 To change the defaults for these fields you can use the `facetsDefaults`
 setting and set your preferred default values there.


### PR DESCRIPTION
This PR extends the facet configuration.
With "showmissing = 1" it is now possible to show all matching documents with no facet value.
The label for this facet option can be configured with "labelmissing".