### PR TITLE
Fix PHP warnings

### DIFF
--- a/Classes/ViewHelpers/Data/ValueForKeyViewHelper.php
+++ b/Classes/ViewHelpers/Data/ValueForKeyViewHelper.php
@@ -54,8 +54,10 @@ class ValueForKeyViewHelper extends AbstractViewHelper
     ) {
         $result = null;
 
-        if ($arguments['array'] && array_key_exists($arguments['key'], $arguments['array'])) {
-            $result = $arguments['array'][$arguments['key']];
+        if (is_int($arguments['key']) || is_string($arguments['key'])) {
+            if ($arguments['array'] && array_key_exists($arguments['key'], $arguments['array'])) {
+                $result = $arguments['array'][$arguments['key']];
+            }
         }
 
         return $result;


### PR DESCRIPTION
Our typo3find installation throws lots of warnings.
This PR should reduce the number of warnings.

I tried to contact you directly via mail.
Maybe it is easier to talk about all PRs I've made?