### PR TITLE
Fix escape logic

### DIFF
--- a/Classes/Service/SolrServiceProvider.php
+++ b/Classes/Service/SolrServiceProvider.php
@@ -1007,7 +1007,7 @@ class SolrServiceProvider extends AbstractServiceProvider
                 // Escape all arguments unless told not to do so.
                 if (!$fieldInfo['noescape']) {
                     $escapedQueryTerms = [];
-                    if (is_array($queryTerms) && [] !== $queryTerms) {
+                    if (is_array($queryTerms) && [] !== $queryTerms && count($queryTerms) > 1) {
                         foreach ($queryTerms as $key => $term) {
                             if ($fieldInfo['phrase']) {
                                 $escapedQueryTerms[$key] = $this->query->getHelper()->escapePhrase($term);
@@ -1044,7 +1044,7 @@ class SolrServiceProvider extends AbstractServiceProvider
                     $magicFieldPrefix .= '{!edismax}';
                 }
 
-                if (2 === $fieldInfo['noescape']) {
+                if (2 === (int) $fieldInfo['noescape']) {
                     $chars = explode(',', $fieldInfo['escapechar']);
                     foreach ($queryTerms as $key => $term) {
                         foreach ($chars as $char) {
@@ -1053,7 +1053,7 @@ class SolrServiceProvider extends AbstractServiceProvider
                     }
 
                     $queryPart = $magicFieldPrefix.vsprintf($queryFormat, $queryTerms);
-                } elseif ($fieldInfo['noescape']) {
+                } elseif (1 === (int) $fieldInfo['noescape']) {
                     $queryPart = $magicFieldPrefix.vsprintf($queryFormat, $queryTerms);
                 } else {
                     $queryPart = $magicFieldPrefix.$this->query->getHelper()->escapePhrase(vsprintf($queryFormat, $queryTerms));


### PR DESCRIPTION
Since `noescape = 2` has been introduced a logic error seems to occur. 

In the following line a phrase escape is forced if the value of `noescape` is neither "2" nor "1":
https://github.com/subugoe/typo3-find/blob/7d58670704f27fdabab67503ae43fab7ead31eea/Classes/Service/SolrServiceProvider.php#L1059

Earlier we already have an escaping perfomed, if there is no argument `noescape`: 
https://github.com/subugoe/typo3-find/blob/7d58670704f27fdabab67503ae43fab7ead31eea/Classes/Service/SolrServiceProvider.php#L1008-L1021

This seems to result in a "double-escape" which produces wrong query terms and therefore wrong or mostly empty results lists.

Furthermore the comparison appears to be type-unsafe.

Please @chrizzor and @ipf have a look at those changes and test them in different environments.

